### PR TITLE
Add LICENSE file to allow installing with yazi-plugin-manager

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 sharklasers996
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This commit adds a LICENSE file to the repository to allow installing the plugin with yazi-plugin-manager.

The LICENSE file is a copy of the MIT license, with the copyright holder's name having been changed to the repository owner's username.

This fixes the following error:

```text
  Deploying package `eza-preview.yazi`

Error: Failed to copy `/home/user/.local/state/yazi/packages/0441ad06d7d13efa65838c08e0fd41ba/LICENSE` to `/home/user/.config/yazi/plugins/eza-preview.yazi/LICENSE`

Caused by:
    No such file or directory (os error 2)
```

https://yazi-rs.github.io/docs/plugins/overview