### PR TITLE
Update yazi init.lua file name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ keymap = [
 ]
 ```
 
-List mode is the default, if you want to have tree mode instead when starting yazi - update `yazi.lua` with:
+List mode is the default, if you want to have tree mode instead when starting yazi - update `~/.config/yazi/init.lua` with:
 
 ```lua
 require("eza-preview"):setup()


### PR DESCRIPTION
the presence of `yazi.lua` was pretty confusing for a beginner to yazi like me. so updated the file name to correct one.