### PR TITLE
feat: implement default level, increment and decrement level

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tree mode:
 
 ## Requirements
 
-- [yazi](https://github.com/sxyazi/yazi)
+- [yazi (0.4+) or nightly](https://github.com/sxyazi/yazi)
 - [eza](https://github.com/eza-community/eza)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -26,22 +26,26 @@ git clone https://github.com/sharklasers996/eza-preview.yazi ~/.config/yazi/plug
 Add `eza-preview` to previewers in `yazi.toml`:
 
 ```toml
-prepend_previewers = [
-	{ name = "*/", run = "eza-preview" },
-]
+[[plugin.prepend_previewers]]
+name = "*/"
+run = "eza-preview"
 ```
 
 Set key binding to switch between list and tree modes in `keymap.toml`:
 
 ```toml
 [manager]
-keymap = [
-	{ on = [ "E" ], run = "plugin eza-preview",  desc = "Toggle tree/list dir preview" },
+prepend_keymap = [
+  { on = [ "E" ], run = "plugin eza-preview",  desc = "Toggle tree/list dir preview" },
+  { on = [ "-" ], run = "plugin eza-preview --args='inc-level'", desc = "Increment tree level" },
+  { on = [ "_" ], run = "plugin eza-preview --args='dec-level'", desc = "Decrement tree level" },
 ]
 ```
 
-List mode is the default, if you want to have tree mode instead when starting yazi - update `yazi.lua` with:
+List mode is the default, if you want to have tree mode instead when starting yazi - update `init.lua` with:
 
 ```lua
-require("eza-preview"):setup()
+require("eza-preview"):setup{
+  level = 2 -- default level: 3
+}
 ```

--- a/init.lua
+++ b/init.lua
@@ -30,14 +30,36 @@ local get_opts = ya.sync(function(state)
 	return state.opts
 end)
 
+local inc_level = ya.sync(function(state)
+	state.opts.level = state.opts.level + 1
+end)
+
+local dec_level = ya.sync(function(state)
+	if state.opts.level > 1 then
+		state.opts.level = state.opts.level - 1
+	end
+end)
+
 function M:setup(opts)
 	set_opts(opts)
 
 	toggle_view_mode()
 end
 
-function M:entry()
-	toggle_view_mode()
+function M:entry(args)
+	if args[1] then
+		local arg = args[1]
+
+		if arg == "inc-level" then
+			inc_level()
+		end
+
+		if arg == "dec-level" then
+			dec_level()
+		end
+	else
+		toggle_view_mode()
+	end
 
 	ya.manager_emit("seek", { 0 })
 end

--- a/init.lua
+++ b/init.lua
@@ -16,20 +16,37 @@ local is_tree_view_mode = ya.sync(function(state, _)
 	return state.tree
 end)
 
-function M:setup()
+local set_opts = ya.sync(function(state, opts)
+	if state.opts == nil then
+		state.opts = { level = 3 }
+	end
+
+	for key, value in pairs(opts or {}) do
+		state.opts[key] = value
+	end
+end)
+
+local get_opts = ya.sync(function(state)
+	return state.opts
+end)
+
+function M:setup(opts)
+	set_opts(opts)
+
 	toggle_view_mode()
 end
 
-function M:entry(_)
+function M:entry()
 	toggle_view_mode()
 
 	ya.manager_emit("seek", { 0 })
 end
 
 function M:peek()
+	local level = get_opts().level
+
 	local args = {
-		"-a",
-		"--oneline",
+		"--all",
 		"--color=always",
 		"--icons=always",
 		"--group-directories-first",
@@ -38,7 +55,8 @@ function M:peek()
 	}
 
 	if is_tree_view_mode() then
-		table.insert(args, "-T")
+		table.insert(args, "--tree")
+		table.insert(args, string.format("--level=%d", level))
 	end
 
 	local child = Command("eza"):args(args):stdout(Command.PIPED):stderr(Command.PIPED):spawn()

--- a/init.lua
+++ b/init.lua
@@ -1,105 +1,102 @@
 local M = {}
 
-local function fail(s, ...) ya.notify { title = "Eza Preview", content = string.format(s, ...), timeout = 5, level =
-    "error" } end
+local function fail(s, ...)
+	ya.notify({ title = "Eza Preview", content = string.format(s, ...), timeout = 5, level = "error" })
+end
 
 local toggle_view_mode = ya.sync(function(state, _)
-    if state.tree == nil then
-        state.tree = false
-    end
+	if state.tree == nil then
+		state.tree = false
+	end
 
-    state.tree = not state.tree
+	state.tree = not state.tree
 end)
 
 local is_tree_view_mode = ya.sync(function(state, _)
-    return state.tree
+	return state.tree
 end)
 
 function M:setup()
-    toggle_view_mode()
+	toggle_view_mode()
 end
 
 function M:entry(_)
-    toggle_view_mode()
+	toggle_view_mode()
 
-    ya.manager_emit("seek", { 0 })
+	ya.manager_emit("seek", { 0 })
 end
 
 function M:peek()
-    local args = {
-        "-a",
-        "--oneline",
-        "--color=always",
-        "--icons=always",
-        "--group-directories-first",
-        "--no-quotes",
-        tostring(self.file.url)
-    }
+	local args = {
+		"-a",
+		"--oneline",
+		"--color=always",
+		"--icons=always",
+		"--group-directories-first",
+		"--no-quotes",
+		tostring(self.file.url),
+	}
 
-    if is_tree_view_mode() then
-        table.insert(args, "-T")
-    end
+	if is_tree_view_mode() then
+		table.insert(args, "-T")
+	end
 
-    local child = Command("eza")
-        :args(args)
-        :stdout(Command.PIPED)
-        :stderr(Command.PIPED)
-        :spawn()
+	local child = Command("eza"):args(args):stdout(Command.PIPED):stderr(Command.PIPED):spawn()
 
-    local limit = self.area.h
-    local lines = ""
-    local num_lines = 1
-    local num_skip = 0
-    local empty_output = false
+	local limit = self.area.h
+	local lines = ""
+	local num_lines = 1
+	local num_skip = 0
+	local empty_output = false
 
-    repeat
-        local line, event = child:read_line()
-        if event == 1 then
-            fail(tostring(event))
-        elseif event ~= 0 then
-            break
-        end
+	repeat
+		local line, event = child:read_line()
+		if event == 1 then
+			fail(tostring(event))
+		elseif event ~= 0 then
+			break
+		end
 
-        if num_skip >= self.skip then
-            lines = lines .. line
-            num_lines = num_lines + 1
-        else
-            num_skip = num_skip + 1
-        end
-    until num_lines >= limit
+		if num_skip >= self.skip then
+			lines = lines .. line
+			num_lines = num_lines + 1
+		else
+			num_skip = num_skip + 1
+		end
+	until num_lines >= limit
 
-    if num_lines == 1 and not is_tree_view_mode() then
-        empty_output = true
-    elseif num_lines == 2 and is_tree_view_mode() then
-        empty_output = true
-    end
+	if num_lines == 1 and not is_tree_view_mode() then
+		empty_output = true
+	elseif num_lines == 2 and is_tree_view_mode() then
+		empty_output = true
+	end
 
-    child:start_kill()
-    if self.skip > 0 and num_lines < limit then
-        ya.manager_emit(
-            "peek",
-            { tostring(math.max(0, self.skip - (limit - num_lines))), only_if = tostring(self.file.url), upper_bound = "" }
-        )
-    elseif empty_output then
-        ya.preview_widgets(self, {
-            ui.Paragraph(self.area, { ui.Line("No items") })
-                :align(ui.Paragraph.CENTER),
-        })
-    else
-        ya.preview_widgets(self, { ui.Paragraph.parse(self.area, lines) })
-    end
+	child:start_kill()
+	if self.skip > 0 and num_lines < limit then
+		ya.manager_emit("peek", {
+			tostring(math.max(0, self.skip - (limit - num_lines))),
+			only_if = tostring(self.file.url),
+			upper_bound = "",
+		})
+	elseif empty_output then
+		ya.preview_widgets(self, {
+			ui.Text({ ui.Line("No items") }):area(self.area):align(ui.Text.CENTER),
+		})
+	else
+		ya.preview_widgets(self, { ui.Text.parse(lines):area(self.area) })
+	end
 end
 
 function M:seek(units)
-    local h = cx.active.current.hovered
-    if h and h.url == self.file.url then
-        local step = math.floor(units * self.area.h / 10)
-        ya.manager_emit("peek", {
-            math.max(0, cx.active.preview.skip + step),
-            only_if = tostring(self.file.url),
-            force = true
-        })
-    end
+	local h = cx.active.current.hovered
+	if h and h.url == self.file.url then
+		local step = math.floor(units * self.area.h / 10)
+		ya.manager_emit("peek", {
+			math.max(0, cx.active.preview.skip + step),
+			only_if = tostring(self.file.url),
+			force = true,
+		})
+	end
 end
 
 return M


### PR DESCRIPTION
This PR adds the following features:

- Configurable tree level. The default level is set to 3
- Increment and Decrement level while using the tree view

```lua
require("eza-preview"):setup {
  level = 2 -- default level: 3
}
```

To increment the `level` state:

```bash
plugin eza-preview --args="inc-level"
```

```bash
plugin eza-preview --args="dec-level"
```

## Demo 📸
![Screen Recording 2024-11-21 at 1 11 39 PM](https://github.com/user-attachments/assets/e4fef496-3179-45ac-81fb-e2bf1fbe9796)

In this demo, I'm using - to increase the tree level and _ to decrease it
