### PR TITLE
[#1772] Fix deprecated API ui.Paragraph

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -82,8 +82,8 @@ function M:peek()
         )
     elseif empty_output then
         ya.preview_widgets(self, {
-            ui.Paragraph(self.area, { ui.Line("No items") })
-                :align(ui.Paragraph.CENTER),
+            ui.Text({ ui.Line("No items") }):area(self.area)
+                :align(ui.Text.CENTER),
         })
     else
         ya.preview_widgets(self, { ui.Paragraph.parse(self.area, lines) })


### PR DESCRIPTION
Fix following error message:
---

Deprecated API:
The `ui.Paragraph` and `ui.ListItem` elements have been deprecated in Yazi v0.4.
Please use the new `ui.Text` instead, in your `eza-preview.yazi` plugin. See issue #1772 for details: https://github.com/sxyazi/yazi/issues/1772